### PR TITLE
add derive-conv derive macro for simplify type conv

### DIFF
--- a/macros/derive-conv/Cargo.toml
+++ b/macros/derive-conv/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "derive-conv"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+darling = "0.20.3"
+quote = "1.0.32"
+syn = "2.0.28"

--- a/macros/derive-conv/src/derive_input_conv/common/callable.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/callable.rs
@@ -1,10 +1,10 @@
-
 /// 需要实现 [FromMeta](darling::FromMeta)
-/// 
+///
 /// 表示一个可以作为函数调用的表达式，有以下的情况
-/// 
+///
 /// 1. 用户提供一个 [`Path`](syn::Path), 这个路径是一个函数的路径
-/// 2. 用户提供一个 [`Closure`](syn::ExprClosure), 这是一个闭包，在原地声明函数的操作
-pub enum Callable{
+/// 2. 用户提供一个 [`Closure`](syn::ExprClosure),
+///    这是一个闭包，在原地声明函数的操作
+pub enum Callable {
     // TODO： 完成可调用对象解析
 }

--- a/macros/derive-conv/src/derive_input_conv/common/callable.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/callable.rs
@@ -1,0 +1,10 @@
+
+/// 需要实现 [FromMeta](darling::FromMeta)
+/// 
+/// 表示一个可以作为函数调用的表达式，有以下的情况
+/// 
+/// 1. 用户提供一个 [`Path`](syn::Path), 这个路径是一个函数的路径
+/// 2. 用户提供一个 [`Closure`](syn::ExprClosure), 这是一个闭包，在原地声明函数的操作
+pub enum Callable{
+    // TODO： 完成可调用对象解析
+}

--- a/macros/derive-conv/src/derive_input_conv/common/list.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/list.rs
@@ -1,0 +1,6 @@
+/// 解析输入参数中类型相同的列表项
+/// 需要实现 [FromMeta](darling::FromMeta)
+/// 
+/// 当 输入 [`Meta`](syn::Meta) 类型为 [`Meta::List`](syn::Meta::List)，
+/// 将每个列表元素解析为对应Item
+pub struct List<Item>(pub Vec<Item>);

--- a/macros/derive-conv/src/derive_input_conv/common/list.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/list.rs
@@ -1,6 +1,6 @@
 /// 解析输入参数中类型相同的列表项
 /// 需要实现 [FromMeta](darling::FromMeta)
-/// 
+///
 /// 当 输入 [`Meta`](syn::Meta) 类型为 [`Meta::List`](syn::Meta::List)，
 /// 将每个列表元素解析为对应Item
 pub struct List<Item>(pub Vec<Item>);

--- a/macros/derive-conv/src/derive_input_conv/common/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod require_list;
 pub(crate) mod callable;
 pub(crate) mod list;
+pub(crate) mod require_list;

--- a/macros/derive-conv/src/derive_input_conv/common/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod require_list;
+pub(crate) mod callable;
+pub(crate) mod list;

--- a/macros/derive-conv/src/derive_input_conv/common/require_list.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/require_list.rs
@@ -1,0 +1,40 @@
+use std::marker::PhantomData;
+use crate::derive_input_conv::common::list::List;
+
+
+/// 对于每一个 require item 项，都需要以下内容
+///
+/// - var_name: 需要的变量（来自preprocess）或者field(来自Self/Model)的名称
+/// - require_mode: 需要的变量的模式，包括以下几种
+///     - `Ref`(default): 默认情况为取得原始值的不可变引用
+///     - `RefMut`: 取得对应变量的不可变引用
+///     - `Owned`: 取得所有权（对应的field 会被标记为 `ignore`)
+///     - `Copy`: 使用Copy 取得所有权，（对应的field 不会被标记为 `ignore`）
+//TODO 完成参数需求项解析
+pub struct RequireItem<Mode = FullMode> {
+    _phantom: PhantomData<Mode>,
+}
+
+
+pub type RequireList<Mode = FullMode> = List<RequireItem<Mode>>;
+
+
+pub struct FullMode;
+
+pub struct RefOnlyMode;
+/// 生成转换代码的标记
+///需要实现 [FromMeta](darling::FromMeta)
+/// 
+/// 将对应输入的字面量转换为对应的枚举项。如
+/// - `"mut"` -> `Self::RefMut`,
+/// - `"ref"` -> `Self::Ref`,
+/// - `"owned"` -> `Self::Owned`,
+/// - `"copy"` -> `Self::Copy`,
+/// 
+/// 如果无法转换为任意的枚举项，报错
+pub enum RequireMode {
+    Ref,
+    RefMut,
+    Owned,
+    Copy,
+}

--- a/macros/derive-conv/src/derive_input_conv/common/require_list.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/require_list.rs
@@ -2,6 +2,8 @@ use std::marker::PhantomData;
 
 use crate::derive_input_conv::common::list::List;
 
+/// 需要实现 [FromMeta](darling::FromMeta)
+///
 /// 对于每一个 require item 项，都需要以下内容
 ///
 /// - var_name: 需要的变量（来自preprocess）或者field(来自Self/Model)的名称

--- a/macros/derive-conv/src/derive_input_conv/common/require_list.rs
+++ b/macros/derive-conv/src/derive_input_conv/common/require_list.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
-use crate::derive_input_conv::common::list::List;
 
+use crate::derive_input_conv::common::list::List;
 
 /// 对于每一个 require item 项，都需要以下内容
 ///
@@ -10,27 +10,25 @@ use crate::derive_input_conv::common::list::List;
 ///     - `RefMut`: 取得对应变量的不可变引用
 ///     - `Owned`: 取得所有权（对应的field 会被标记为 `ignore`)
 ///     - `Copy`: 使用Copy 取得所有权，（对应的field 不会被标记为 `ignore`）
-//TODO 完成参数需求项解析
+// TODO 完成参数需求项解析
 pub struct RequireItem<Mode = FullMode> {
     _phantom: PhantomData<Mode>,
 }
 
-
 pub type RequireList<Mode = FullMode> = List<RequireItem<Mode>>;
-
 
 pub struct FullMode;
 
 pub struct RefOnlyMode;
 /// 生成转换代码的标记
-///需要实现 [FromMeta](darling::FromMeta)
-/// 
+/// 需要实现 [FromMeta](darling::FromMeta)
+///
 /// 将对应输入的字面量转换为对应的枚举项。如
 /// - `"mut"` -> `Self::RefMut`,
 /// - `"ref"` -> `Self::Ref`,
 /// - `"owned"` -> `Self::Owned`,
 /// - `"copy"` -> `Self::Copy`,
-/// 
+///
 /// 如果无法转换为任意的枚举项，报错
 pub enum RequireMode {
     Ref,

--- a/macros/derive-conv/src/derive_input_conv/container/conv_mode.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/conv_mode.rs
@@ -1,0 +1,18 @@
+/// 生成转换代码的标记
+///
+/// 需要实现 [FromMeta](darling::FromMeta)
+///
+/// 将对应输入的字面量转换为对应的枚举项。如
+/// - `"IntoActiveModel"` -> `Self::IntoActiveModel`
+///
+/// 如果无法转换为任意的枚举项，报错
+///
+/// ## NOTE
+///
+/// `FromModel` 与其他 2 者为互斥关系
+// todo 完成 ConvMode 参数解析
+pub enum ConvMode{
+    IntoActiveModel,
+    UpdateActiveModel,
+    FromModel
+}

--- a/macros/derive-conv/src/derive_input_conv/container/conv_mode.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/conv_mode.rs
@@ -11,8 +11,8 @@
 ///
 /// `FromModel` 与其他 2 者为互斥关系
 // todo 完成 ConvMode 参数解析
-pub enum ConvMode{
+pub enum ConvMode {
     IntoActiveModel,
     UpdateActiveModel,
-    FromModel
+    FromModel,
 }

--- a/macros/derive-conv/src/derive_input_conv/container/generate_fields.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/generate_fields.rs
@@ -2,18 +2,16 @@ use crate::derive_input_conv::common::list::List;
 
 /// 为转换提供额外的field
 /// 需要实现 [FromMeta](darling::FromMeta)
-/// 
+///
 /// - 如果为 `IntoActiveModel` 模式，会添加额外的 `Set` 项，
 /// - 如果为 `UpdateActiveModel` 模式，会更新这些额外项，
 /// - 如果为 `FromModel` 模式，忽略该参数
-/// 
+///
 /// 需要以下内容
 /// - field_name: 额外添加的field 的名称，
 /// - from_var（optional）: field 的值的来处，只能来自于 preprocess 结果。
 /// 如果该field 未提供，那么就与 field_name 相同
 // TODO: 完成额外Field 参数解析
-pub struct GenerateField{
-    
-}
+pub struct GenerateField {}
 
 pub type GenerateFields = List<GenerateField>;

--- a/macros/derive-conv/src/derive_input_conv/container/generate_fields.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/generate_fields.rs
@@ -1,0 +1,19 @@
+use crate::derive_input_conv::common::list::List;
+
+/// 为转换提供额外的field
+/// 需要实现 [FromMeta](darling::FromMeta)
+/// 
+/// - 如果为 `IntoActiveModel` 模式，会添加额外的 `Set` 项，
+/// - 如果为 `UpdateActiveModel` 模式，会更新这些额外项，
+/// - 如果为 `FromModel` 模式，忽略该参数
+/// 
+/// 需要以下内容
+/// - field_name: 额外添加的field 的名称，
+/// - from_var（optional）: field 的值的来处，只能来自于 preprocess 结果。
+/// 如果该field 未提供，那么就与 field_name 相同
+// TODO: 完成额外Field 参数解析
+pub struct GenerateField{
+    
+}
+
+pub type GenerateFields = List<GenerateField>;

--- a/macros/derive-conv/src/derive_input_conv/container/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/mod.rs
@@ -1,20 +1,21 @@
-
-
 mod conv_mode;
-mod preprocess;
 mod generate_fields;
+mod preprocess;
 
 /// 容器的参数解析
-/// 
+///
 /// 需要实现 [FromMeta](darling::FromMeta)
-/// 
+///
 /// ## 需要参数
-/// - `mode` : 需要生成的模块，可以提供一个或者多个，类型为 [ConvMode](conv_mode::ConvMode)
+/// - `mode` : 需要生成的模块，可以提供一个或者多个，类型为
+///   [ConvMode](conv_mode::ConvMode)
 /// - `target`: 生成的目标Model, SQL 的 Model，类型为 [`Type`](syn::Type)
-/// - `preprocess`: 预处理过程，类型为 [`Preprocess`](preprocess::Preprocess),注意预处理过程可能有0个或者多个
-/// - `non_exist_use_default`（optional）: `IntoActiveModel` 专用参数，未提供的值使用 [`Default::default`]填充，
-/// 类型为 [bool], 
-/// - `generate_fields`(optional): 额外生成的field, 类型为 [`GenerateFields`](generate_fields::GenerateFields)
+/// - `preprocess`: 预处理过程，类型为
+///   [`Preprocess`](preprocess::Preprocess),注意预处理过程可能有0个或者多个
+/// - `non_exist_use_default`（optional）: `IntoActiveModel`
+///   专用参数，未提供的值使用 [`Default::default`]填充，
+/// 类型为 [bool],
+/// - `generate_fields`(optional): 额外生成的field, 类型为
+///   [`GenerateFields`](generate_fields::GenerateFields)
 // TODO 完成容器的参数解析
-pub struct ContainerDeriveInput{
-}
+pub struct ContainerDeriveInput {}

--- a/macros/derive-conv/src/derive_input_conv/container/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/mod.rs
@@ -1,0 +1,20 @@
+
+
+mod conv_mode;
+mod preprocess;
+mod generate_fields;
+
+/// 容器的参数解析
+/// 
+/// 需要实现 [FromMeta](darling::FromMeta)
+/// 
+/// ## 需要参数
+/// - `mode` : 需要生成的模块，可以提供一个或者多个，类型为 [ConvMode](conv_mode::ConvMode)
+/// - `target`: 生成的目标Model, SQL 的 Model，类型为 [`Type`](syn::Type)
+/// - `preprocess`: 预处理过程，类型为 [`Preprocess`](preprocess::Preprocess),注意预处理过程可能有0个或者多个
+/// - `non_exist_use_default`（optional）: `IntoActiveModel` 专用参数，未提供的值使用 [`Default::default`]填充，
+/// 类型为 [bool], 
+/// - `generate_fields`(optional): 额外生成的field, 类型为 [`GenerateFields`](generate_fields::GenerateFields)
+// TODO 完成容器的参数解析
+pub struct ContainerDeriveInput{
+}

--- a/macros/derive-conv/src/derive_input_conv/container/preprocess.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/preprocess.rs
@@ -1,0 +1,26 @@
+
+pub mod skip_mode;
+
+/// 解析预处理内容参数
+/// 需要实现 [FromMeta](darling::FromMeta)
+///
+/// ## 预处理需要以下的参数
+/// 
+/// - var(optional): 接受预处理结果的表达式。如果预处理过程本身没有结果，可以不提供，
+/// - process: 预处理过程本身，为一个 [`Callable`](super::super::common::callable::Callable) 对象。
+/// 这个函数的参数列表为 `requires` 按顺序传入，返回值与 `var` 相匹配
+/// - requires（optional）: 预处理过程的额外参数，来自`Self`,
+/// 如果预处理过程不需要除了 `Self` 以外的任何参数，可以不提供requires
+/// - require_self(optional): 预处理过程需要 `Self`,可以通过提供值来获得 `&mut Self` 或者 `Copy Self`,
+/// 否则默认为 `& Self` ，以下为可能的参数传递方式
+///     - `require_self`: 获得 `&Self`
+///     - `require_self = "mut"` 获得 `&Self`
+///     - `require_self = "copy"` 获得 `Self` (Self 本身所有权转移语义为 COPY)
+/// 
+/// ## NOTE
+/// 
+/// 请注意 `requires` 与 `require_self` 是互斥的参数,即同时只能提供一个参数，如果同时提供需要报错。
+// TODO: 完成预处理流程的参数解析
+pub struct Preprocess{
+}
+

--- a/macros/derive-conv/src/derive_input_conv/container/preprocess.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/preprocess.rs
@@ -1,26 +1,27 @@
-
 pub mod skip_mode;
 
 /// 解析预处理内容参数
 /// 需要实现 [FromMeta](darling::FromMeta)
 ///
 /// ## 预处理需要以下的参数
-/// 
-/// - var(optional): 接受预处理结果的表达式。如果预处理过程本身没有结果，可以不提供，
-/// - process: 预处理过程本身，为一个 [`Callable`](super::super::common::callable::Callable) 对象。
+///
+/// - var(optional):
+///   接受预处理结果的表达式。如果预处理过程本身没有结果，可以不提供，
+/// - process: 预处理过程本身，为一个
+///   [`Callable`](super::super::common::callable::Callable) 对象。
 /// 这个函数的参数列表为 `requires` 按顺序传入，返回值与 `var` 相匹配
 /// - requires（optional）: 预处理过程的额外参数，来自`Self`,
 /// 如果预处理过程不需要除了 `Self` 以外的任何参数，可以不提供requires
-/// - require_self(optional): 预处理过程需要 `Self`,可以通过提供值来获得 `&mut Self` 或者 `Copy Self`,
+/// - require_self(optional): 预处理过程需要 `Self`,可以通过提供值来获得 `&mut
+///   Self` 或者 `Copy Self`,
 /// 否则默认为 `& Self` ，以下为可能的参数传递方式
 ///     - `require_self`: 获得 `&Self`
 ///     - `require_self = "mut"` 获得 `&Self`
 ///     - `require_self = "copy"` 获得 `Self` (Self 本身所有权转移语义为 COPY)
-/// 
+///
 /// ## NOTE
-/// 
-/// 请注意 `requires` 与 `require_self` 是互斥的参数,即同时只能提供一个参数，如果同时提供需要报错。
+///
+/// 请注意 `requires` 与 `require_self`
+/// 是互斥的参数,即同时只能提供一个参数，如果同时提供需要报错。
 // TODO: 完成预处理流程的参数解析
-pub struct Preprocess{
-}
-
+pub struct Preprocess {}

--- a/macros/derive-conv/src/derive_input_conv/container/preprocess.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/preprocess.rs
@@ -16,7 +16,7 @@ pub mod skip_mode;
 ///   Self` 或者 `Copy Self`,
 /// 否则默认为 `& Self` ，以下为可能的参数传递方式
 ///     - `require_self`: 获得 `&Self`
-///     - `require_self = "mut"` 获得 `&Self`
+///     - `require_self = "mut"` 获得 `&mut Self`
 ///     - `require_self = "copy"` 获得 `Self` (Self 本身所有权转移语义为 COPY)
 ///
 /// ## NOTE

--- a/macros/derive-conv/src/derive_input_conv/container/preprocess/skip_mode.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/preprocess/skip_mode.rs
@@ -1,17 +1,17 @@
 /// 与粗砺过程可以在生成某些模式中不执行，通过该参数指定
 /// 需要实现 [FromMeta](darling::FromMeta)
-/// 
+///
 /// ## 输入格式
 /// mode 名称为 [`ConvMode`](super::super::conv_mode::ConvMode) 的对应字面量，
 /// 如果需要在多个模式下不执行，使用 `|` 进行分割，顺序无关。以下为可能的输入
 /// - `"IntoActiveModel"`
 /// - `"UpdateActiveModel|FromModel"`
-/// 
+///
 /// ## Note
-/// 
+///
 /// 不能同时跳过全部的生成模式。比如，以下输入非法
 /// - `UpdateActiveModel|FromModel|IntoActiveModel`
 
-pub struct SkipMode{
-    //TODO 完成预处理过程跳过模式 参数解析
+pub struct SkipMode {
+    // TODO 完成预处理过程跳过模式 参数解析
 }

--- a/macros/derive-conv/src/derive_input_conv/container/preprocess/skip_mode.rs
+++ b/macros/derive-conv/src/derive_input_conv/container/preprocess/skip_mode.rs
@@ -1,0 +1,17 @@
+/// 与粗砺过程可以在生成某些模式中不执行，通过该参数指定
+/// 需要实现 [FromMeta](darling::FromMeta)
+/// 
+/// ## 输入格式
+/// mode 名称为 [`ConvMode`](super::super::conv_mode::ConvMode) 的对应字面量，
+/// 如果需要在多个模式下不执行，使用 `|` 进行分割，顺序无关。以下为可能的输入
+/// - `"IntoActiveModel"`
+/// - `"UpdateActiveModel|FromModel"`
+/// 
+/// ## Note
+/// 
+/// 不能同时跳过全部的生成模式。比如，以下输入非法
+/// - `UpdateActiveModel|FromModel|IntoActiveModel`
+
+pub struct SkipMode{
+    //TODO 完成预处理过程跳过模式 参数解析
+}

--- a/macros/derive-conv/src/derive_input_conv/field/condition_set.rs
+++ b/macros/derive-conv/src/derive_input_conv/field/condition_set.rs
@@ -1,20 +1,21 @@
-
 /// 条件赋值/更新
 /// 需要实现 [FromMeta](darling::FromMeta)
 /// 当符合指定条件时，会赋值，否则不赋值
-/// 
+///
 /// ## 需求参数
-/// - `condition`（optional）: 判定是否进行赋值的函数，类型为 [Callable](super::super::common::callable::Callable),
-/// 该函数的第一个参数为该field本身，转移所有权，后续参数为 `requires` 按顺序进入，只能持有 ref 引用，
-/// 返回值为 `Option<Ty>`, `Ty` 为当前field 的类型， 当返回结果为 `Some` 时，赋值，否则不赋值
-/// - `requires`(optional): 条件赋值判定需要的额外参数列表，只能来自 `preprocess` 结果，只能获取 ref 引用， 
-/// 类型为 [`List<syn::Ident>`](crate::derive_input_conv::common::list::List<syn::Ident>), 
+/// - `condition`（optional）: 判定是否进行赋值的函数，类型为
+///   [Callable](super::super::common::callable::Callable),
+/// 该函数的第一个参数为该field本身，转移所有权，后续参数为 `requires`
+/// 按顺序进入，只能持有 ref 引用， 返回值为 `Option<Ty>`, `Ty` 为当前field
+/// 的类型， 当返回结果为 `Some` 时，赋值，否则不赋值
+/// - `requires`(optional): 条件赋值判定需要的额外参数列表，只能来自
+///   `preprocess` 结果，只能获取 ref 引用，
+/// 类型为 [`List<syn::Ident>`](crate::derive_input_conv::common::list::List<syn::Ident>),
 /// 或者 [`RequireList`](crate::derive_input_conv::common::require_list::RequireList)
-/// 
+///
 /// ## NOTE
 /// 如果 field 的类型本身就为Optional,
 /// 那可以考虑直接进行条件赋值，也就是 `condition` 与 `Requires` 均不提供
-pub struct ConditionSet{
-    //TODO: 完成 `ConditionSet` 条件置值的参数解析
+pub struct ConditionSet {
+    // TODO: 完成 `ConditionSet` 条件置值的参数解析
 }
-

--- a/macros/derive-conv/src/derive_input_conv/field/condition_set.rs
+++ b/macros/derive-conv/src/derive_input_conv/field/condition_set.rs
@@ -1,0 +1,20 @@
+
+/// 条件赋值/更新
+/// 需要实现 [FromMeta](darling::FromMeta)
+/// 当符合指定条件时，会赋值，否则不赋值
+/// 
+/// ## 需求参数
+/// - `condition`（optional）: 判定是否进行赋值的函数，类型为 [Callable](super::super::common::callable::Callable),
+/// 该函数的第一个参数为该field本身，转移所有权，后续参数为 `requires` 按顺序进入，只能持有 ref 引用，
+/// 返回值为 `Option<Ty>`, `Ty` 为当前field 的类型， 当返回结果为 `Some` 时，赋值，否则不赋值
+/// - `requires`(optional): 条件赋值判定需要的额外参数列表，只能来自 `preprocess` 结果，只能获取 ref 引用， 
+/// 类型为 [`List<syn::Ident>`](crate::derive_input_conv::common::list::List<syn::Ident>), 
+/// 或者 [`RequireList`](crate::derive_input_conv::common::require_list::RequireList)
+/// 
+/// ## NOTE
+/// 如果 field 的类型本身就为Optional,
+/// 那可以考虑直接进行条件赋值，也就是 `condition` 与 `Requires` 均不提供
+pub struct ConditionSet{
+    //TODO: 完成 `ConditionSet` 条件置值的参数解析
+}
+

--- a/macros/derive-conv/src/derive_input_conv/field/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/field/mod.rs
@@ -1,28 +1,34 @@
 mod condition_set;
 /// 结构体Field 参数解析
 /// 需要实现 [FromField](darling::FromField)
-/// 
+///
 /// ## 需要内容
 /// - 结构体field 本身
 ///     - ident: field 原始的标识符
 ///     - ty: filed 原始的类型
 /// - Attr 参数
-///     - `ignore`(optional): 转换时忽略该field, 当模式为 `FromModel` 时无效,类型为 [bool]
-///     - `condition_set`(optional): 当符合条件时，才进行赋值/更新， 
-/// 当模式为 `FromModel` 时无效, 类型为 [ConditionSet](condition_set::ConditionSet)
-///     - `rename`(optional): 将该值赋值/修改到 rename 的 field 中，或者 从 rename 的 field 处取得值, 
+///     - `ignore`(optional): 转换时忽略该field, 当模式为 `FromModel`
+///       时无效,类型为 [bool]
+///     - `condition_set`(optional): 当符合条件时，才进行赋值/更新，
+/// 当模式为 `FromModel` 时无效, 类型为
+/// [ConditionSet](condition_set::ConditionSet)
+///     - `rename`(optional): 将该值赋值/修改到 rename 的 field 中，或者 从
+///       rename 的 field 处取得值,
 /// 类型为 [String]
 ///     - `project`（optional）:  对结果作用一个类型转换
-///         - 当为 `IntoActiveModel` 或者 `UpdateActiveModel` 模式时，为将当前field 映射到 ActiveModel 中对应的类型，
-///         - 当为 `FromModel` 时，为将model 中对应的Field 映射到当前field 的类型
-///         - 当该field 被某个 `preprocess` Owned require 时，不作用 任何 projection 
-///         - 类型为 [Callable](super::common::callable::Callable),一个入参，一个返回值
-/// 
+///         - 当为 `IntoActiveModel` 或者 `UpdateActiveModel`
+///           模式时，为将当前field 映射到 ActiveModel 中对应的类型，
+///         - 当为 `FromModel` 时，为将model 中对应的Field 映射到当前field
+///           的类型
+///         - 当该field 被某个 `preprocess` Owned require 时，不作用 任何
+///           projection
+///         - 类型为 [Callable](super::common::callable::Callable),一个入参，
+///           一个返回值
+///
 /// ## NOTE
-/// 
+///
 /// 1. `ignore` 参数与其他的 attr 参数互斥
-/// 2. `project` 会在 `condition_set` 后进行，即 `condition_set` 的参数本身是原始的值与类型
+/// 2. `project` 会在 `condition_set` 后进行，即 `condition_set`
+///    的参数本身是原始的值与类型
 // TODO 完成Field 输入参数解析
-pub struct FieldInput{
-    
-}
+pub struct FieldInput {}

--- a/macros/derive-conv/src/derive_input_conv/field/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/field/mod.rs
@@ -13,12 +13,12 @@ mod condition_set;
 /// 当模式为 `FromModel` 时无效, 类型为
 /// [ConditionSet](condition_set::ConditionSet)
 ///     - `rename`(optional): 将该值赋值/修改到 rename 的 field 中，或者 从
-///       rename 的 field 处取得值,
+///       Model 中名为 rename 的 field 处取得值,
 /// 类型为 [String]
 ///     - `project`（optional）:  对结果作用一个类型转换
 ///         - 当为 `IntoActiveModel` 或者 `UpdateActiveModel`
-///           模式时，为将当前field 映射到 ActiveModel 中对应的类型，
-///         - 当为 `FromModel` 时，为将model 中对应的Field 映射到当前field
+///           模式时，为将当前field 映射到 ActiveModel 中对应的 field 的类型
+///         - 当为 `FromModel` 时，为将 model 中对应的 Field 映射到当前 field
 ///           的类型
 ///         - 当该field 被某个 `preprocess` Owned require 时，不作用 任何
 ///           projection

--- a/macros/derive-conv/src/derive_input_conv/field/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/field/mod.rs
@@ -1,0 +1,28 @@
+mod condition_set;
+/// 结构体Field 参数解析
+/// 需要实现 [FromField](darling::FromField)
+/// 
+/// ## 需要内容
+/// - 结构体field 本身
+///     - ident: field 原始的标识符
+///     - ty: filed 原始的类型
+/// - Attr 参数
+///     - `ignore`(optional): 转换时忽略该field, 当模式为 `FromModel` 时无效,类型为 [bool]
+///     - `condition_set`(optional): 当符合条件时，才进行赋值/更新， 
+/// 当模式为 `FromModel` 时无效, 类型为 [ConditionSet](condition_set::ConditionSet)
+///     - `rename`(optional): 将该值赋值/修改到 rename 的 field 中，或者 从 rename 的 field 处取得值, 
+/// 类型为 [String]
+///     - `project`（optional）:  对结果作用一个类型转换
+///         - 当为 `IntoActiveModel` 或者 `UpdateActiveModel` 模式时，为将当前field 映射到 ActiveModel 中对应的类型，
+///         - 当为 `FromModel` 时，为将model 中对应的Field 映射到当前field 的类型
+///         - 当该field 被某个 `preprocess` Owned require 时，不作用 任何 projection 
+///         - 类型为 [Callable](super::common::callable::Callable),一个入参，一个返回值
+/// 
+/// ## NOTE
+/// 
+/// 1. `ignore` 参数与其他的 attr 参数互斥
+/// 2. `project` 会在 `condition_set` 后进行，即 `condition_set` 的参数本身是原始的值与类型
+// TODO 完成Field 输入参数解析
+pub struct FieldInput{
+    
+}

--- a/macros/derive-conv/src/derive_input_conv/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/mod.rs
@@ -1,6 +1,6 @@
-mod field;
-mod container;
 mod common;
+mod container;
+mod field;
 
 /// 过程宏参数解析
 ///
@@ -12,8 +12,10 @@ mod common;
 /// ## 需要参数
 ///
 /// - `ident`: 原始结构体本身的标识符， 类型为 [`syn::Ident`]
-/// - `container_attr` : 结构体上的输入参数，类型为 [`ContainerDeriveInput`](container::ContainerDeriveInput)
-/// - `fields`: 结构体的field 参数列表，类型为 [`Data<Ignored,field::FieldInput>`](darling::ast::Data)
+/// - `container_attr` : 结构体上的输入参数，类型为
+///   [`ContainerDeriveInput`](container::ContainerDeriveInput)
+/// - `fields`: 结构体的field 参数列表，类型为
+///   [`Data<Ignored,field::FieldInput>`](darling::ast::Data)
 ///
 /// ## Note
 ///
@@ -21,6 +23,4 @@ mod common;
 /// - 该宏只支持 named-struct
 /// - 该宏可能支持 泛型参数
 // TODO: 完成过程宏输入参数解析
-pub struct ConvHelperDeriveInput{
-
-}
+pub struct ConvHelperDeriveInput {}

--- a/macros/derive-conv/src/derive_input_conv/mod.rs
+++ b/macros/derive-conv/src/derive_input_conv/mod.rs
@@ -1,0 +1,26 @@
+mod field;
+mod container;
+mod common;
+
+/// 过程宏参数解析
+///
+/// ## 实现要求
+/// 需要实现 [FromDeriveInput](darling::FromDeriveInput)
+/// - 限制为Named_struct
+/// - 检查不包含任何泛型参数（或者允许部分泛型参数）
+/// - 其他检查...
+/// ## 需要参数
+///
+/// - `ident`: 原始结构体本身的标识符， 类型为 [`syn::Ident`]
+/// - `container_attr` : 结构体上的输入参数，类型为 [`ContainerDeriveInput`](container::ContainerDeriveInput)
+/// - `fields`: 结构体的field 参数列表，类型为 [`Data<Ignored,field::FieldInput>`](darling::ast::Data)
+///
+/// ## Note
+///
+/// - 该宏使用的 attribute 为 `conv`
+/// - 该宏只支持 named-struct
+/// - 该宏可能支持 泛型参数
+// TODO: 完成过程宏输入参数解析
+pub struct ConvHelperDeriveInput{
+
+}

--- a/macros/derive-conv/src/lib.rs
+++ b/macros/derive-conv/src/lib.rs
@@ -42,7 +42,8 @@
 //! ```
 //! - 请参考 [darling](https://github.com/TedDriggs/darling) 文档
 //! - 请参考 [syn](https://docs.rs/syn/latest/syn/) 文档
-//! - 请牢记：宏为替换抽象语法树节点，宏的参数为抽象语法树，宏的结果也为抽象语法树
+//! - 请牢记：宏为替换抽象语法树节点，宏的参数为抽象语法树，
+//!   宏的结果也为抽象语法树
 mod derive_input_conv;
 
 #[proc_macro_derive(ConvHelper, attributes(conv))]

--- a/macros/derive-conv/src/lib.rs
+++ b/macros/derive-conv/src/lib.rs
@@ -40,10 +40,14 @@
 //!     time:String,
 //! }
 //! ```
-//! 请参考 [darling](https://github.com/TedDriggs/darling) 文档
+//! - 请参考 [darling](https://github.com/TedDriggs/darling) 文档
+//! - 请参考 [syn](https://docs.rs/syn/latest/syn/) 文档
+//! - 请牢记：宏为替换抽象语法树节点，宏的参数为抽象语法树，宏的结果也为抽象语法树
 mod derive_input_conv;
 
-#[proc_macro_derive(ConvHelper,attributes(conv))]
-pub fn derive_conv_helper(_input:proc_macro::TokenStream)->proc_macro::TokenStream{
+#[proc_macro_derive(ConvHelper, attributes(conv))]
+pub fn derive_conv_helper(
+    _input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
     todo!()
 }

--- a/macros/derive-conv/src/lib.rs
+++ b/macros/derive-conv/src/lib.rs
@@ -1,7 +1,7 @@
 //! help drive macro for type conv
 //! see issue #155
 //!
-//! ```rust
+//! ```rust norun
 //! use model::Model;
 //!
 //! #[derive(ConvHelper)]
@@ -34,11 +34,16 @@
 //!     id:i32,
 //!     #[conv(ignore)]
 //!     foo:i32,
-//!     #[conv(project(from="Version",by="Version::from"))]
+//!     #[conv(project = "Version::from")]
 //!     bar:String,
 //!     #[conv(rename = "modify_at")]
 //!     time:String,
 //! }
 //! ```
-//!
+//! 请参考 [darling](https://github.com/TedDriggs/darling) 文档
 mod derive_input_conv;
+
+#[proc_macro_derive(ConvHelper,attributes(conv))]
+pub fn derive_conv_helper(_input:proc_macro::TokenStream)->proc_macro::TokenStream{
+    todo!()
+}

--- a/macros/derive-conv/src/lib.rs
+++ b/macros/derive-conv/src/lib.rs
@@ -1,0 +1,44 @@
+//! help drive macro for type conv
+//! see issue #155
+//!
+//! ```rust
+//! use model::Model;
+//!
+//! #[derive(ConvHelper)]
+//! #[conv(mode = "IntoActiveModel",mode = "UpdateActiveModel",mode = "FromModel")]
+//! #[conv(target="Model")]
+//! #[conv(
+//!     preprocess(
+//!         var="(temp_A,foo_auto)",
+//!         process="|foo1,foo2,bar_mut,bar_owned,bar_copy| foo1 + foo2",
+//!         requires(
+//!             foo_default_ref,
+//!             foo = "ref",
+//!             bar_mut = "mut",
+//!             bar_owned = "owned",
+//!             bar_copy = "copy"
+//!         ),
+//!         skip_mode = "update|into|from"
+//!     )
+//! )]
+//! #[conv(non_exist_use_default)]
+//! #[conv(generate_fields(
+//!     foo_auto,
+//!     super_field = "temp_A"
+//! ))]
+//! struct Foo{
+//!     #[conv(condition_set(
+//!     condition = "|this,foo| this > foo",
+//!     requires("foo_auto")
+//!     ))]
+//!     id:i32,
+//!     #[conv(ignore)]
+//!     foo:i32,
+//!     #[conv(project(from="Version",by="Version::from"))]
+//!     bar:String,
+//!     #[conv(rename = "modify_at")]
+//!     time:String,
+//! }
+//! ```
+//!
+mod derive_input_conv;


### PR DESCRIPTION
这是该宏可能的使用场景，该示例中尽可能使用了全部特征
```rust
use model::Model;
#[derive(ConvHelper)]
#[conv(mode = "IntoActiveModel",mode = "UpdateActiveModel",mode = "FromModel")]
#[conv(target="Model")]
#[conv(
    preprocess(
        var="(temp_A,foo_auto)",
        process="|foo1,foo2,bar_mut,bar_owned,bar_copy| foo1 + foo2",
        requires(
            foo_default_ref,
            foo = "ref",
            bar_mut = "mut",
            bar_owned = "owned",
            bar_copy = "copy"
        ),
        skip_mode = "update|into|from"
    )
)]
#[conv(non_exist_use_default)]
#[conv(generate_fields(
    foo_auto,
    super_field = "temp_A"
))]
struct Foo{
    #[conv(condition_set(
    condition = "|this,foo| this > foo",
    requires("foo_auto")
    ))]
    id:i32,
    #[conv(ignore)]
    foo:i32,
    #[conv(project(from="Version",by="Version::from"))]
    bar:String,
    #[conv(rename = "modify_at")]
    time:String,
}
```

---
## 当前进度
- [ ] 宏生成
  - [ ] 宏参数解析
     - [ ]  container参数解析
       - [ ] `mode` 解析
       - [ ] `target` 解析
       - [ ] `preprocess` 解析
         - [ ] `requires` 参数解析
         - [ ] `var` 参数解析
         - [ ] `process` 参数解析
         - [ ] `skip` 参数解析
         - [ ] `require_self` 参数解析
       - [ ] `generate_fields` 解析
     - [ ] feild 参数解析
       - [ ] `project` 解析
       - [ ] `rename` 解析
       - [ ] `ignore` 解析
 - [ ] 宏生成
   - [ ] `IntoActiveModel` 生成
     - [ ] 实现 trait  `IntoActiveModel`
   - [ ]  `UpdateActiveModel` 生成
     - [ ] 添加 `UpdateActiveModel` trait
     - [ ] 实现 trait  `UpdateActiveModel`
   - [ ] `FromModel` 生成
     - [ ] 实现trait `From<Model>` 
